### PR TITLE
Fix publisher mapping

### DIFF
--- a/observer.py
+++ b/observer.py
@@ -29,7 +29,7 @@ def get_publishers(network):
     except (OSError, ValueError, TypeError, FileNotFoundError):
         logger.error("problem loading publishers.json only keys will be printed")
         json_data = {}
-    return {key: name for name, key in json_data.get(network, {}).items()}
+    return json_data.get(network, {})
 
 
 async def main(args):

--- a/pyth_observer/prices.py
+++ b/pyth_observer/prices.py
@@ -52,8 +52,8 @@ class Price:
 
     def publisher_name(self, publisher_key: str) -> str:
         return self._publishers.get(
-            publisher_key,
-            publisher_key,
+            publisher_key.lower(),
+            publisher_key.lower(),
         )
 
     def is_aggregate_publishing(self) -> bool:


### PR DESCRIPTION
Given a publishers.json such as the following:

    {
        "mainnet": {
            "pubkey123": "degen_publisher",
            "pubkey234": "boredape"
        },
        "testnet": {
            "pubkey456": "degen_publisher",
            "pubkey789": "boredape"
        }
    }

Properly map the names to more hooman friendly equivalents.