### PR TITLE
fix zero division error in PriceDeviation when aggregate price is 0

### DIFF
--- a/pyth_observer/calendar.py
+++ b/pyth_observer/calendar.py
@@ -1,0 +1,46 @@
+import datetime
+
+EQUITY_START = datetime.time(9, 30, 0)
+EQUITY_CLOSE = datetime.time(16, 0, 0)
+EQUITY_EARLY_CLOSE = datetime.time(13, 0, 0)
+EQUITY_HOLIDAYS = ["2022-01-17", "2022-02-21", "2022-04-15", "2022-05-30",
+                   "2022-06-20", "2022-07-04", "2022-09-05", "2022-11-24", "2022-11-25", "2022-12-26"]
+EQUITY_HOLIDAYS_EARLY = ["2022-11-25"]
+EQUITY_TRADING_DAYS = [1, 2, 3, 4, 5]
+
+FX_START = datetime.time(17, 0, 0)
+FX_CLOSE = datetime.time(16, 0, 0)
+FX_TRADING_DAYS = [7, 1, 2, 3, 4, 5]
+
+METAL_START = datetime.time(18, 3, 0)
+METAL_CLOSE = datetime.time(16, 58, 0)
+METAL_TRADING_DAYS = [7, 1, 2, 3, 4, 5]
+
+
+class Calendar:
+    def is_market_open(self, product, dt):
+        day, date, time = dt.weekday(), dt.date(), dt.time()
+        if product.attrs["asset_type"] == "Equity":
+            # market holiday
+            if date.strftime("%Y-%m-%d") in EQUITY_HOLIDAYS:
+                # market within early closing hours
+                if date.strftime("%Y-%m-%d") in EQUITY_HOLIDAYS_EARLY and time >= EQUITY_START and time <= EQUITY_EARLY_CLOSE:
+                    breakpoint()
+                    return True
+                # market after holiday closing hours
+                return False
+            # market within regular opening hours
+            if day in EQUITY_TRADING_DAYS and time >= EQUITY_START and time <= EQUITY_CLOSE:
+                return True
+            # market closed
+            return False
+        elif product.attrs["asset_type"] == "FX":
+            if day in FX_TRADING_DAYS:
+                if (day == 7 and time < FX_START) or (day == 5 and time > FX_CLOSE):
+                    return False
+                return True
+            return False
+        elif product.attrs["asset_type"] == "Metal":
+            pass
+        else:  # Crypto
+            return True

--- a/pyth_observer/events.py
+++ b/pyth_observer/events.py
@@ -241,6 +241,8 @@ class StoppedPublishing(PriceValidationEvent):
             f"Published last slot: {self.publisher_latest.slot}"
         )
 
+        return title, details
+
 
 # Price Account events
 

--- a/pyth_observer/events.py
+++ b/pyth_observer/events.py
@@ -200,7 +200,7 @@ class PriceDeviation(PriceValidationEvent):
         agg = self.price.aggregate
         published = self.publisher_aggregate
         if self.price.aggregate.price == 0:
-            title = f"Aggregate price is $0 on {self.symbol}"
+            title = f"Aggregate price is 0 on {self.symbol}"
             details = [
                 f"Aggregate: {agg.price:.2f} ± {agg.confidence_interval:.2f} (slot {agg.slot})",
                 f"Published:  {published.price:.2f} ± {published.confidence_interval:.2f} (slot {published.slot})",

--- a/pyth_observer/events.py
+++ b/pyth_observer/events.py
@@ -186,6 +186,7 @@ class PriceDeviation(PriceValidationEvent):
     def is_valid(self) -> bool:
         delta = self.publisher_aggregate.price - self.price.aggregate.price
         if self.price.aggregate.price == 0:
+            self.deviation = 0
             return False
         else:
             self.deviation = abs(delta / self.price.aggregate.price) * 100

--- a/pyth_observer/events.py
+++ b/pyth_observer/events.py
@@ -199,7 +199,7 @@ class PriceDeviation(PriceValidationEvent):
     def get_event_details(self) -> Tuple[str, List[str]]:
         agg = self.price.aggregate
         published = self.publisher_aggregate
-        if not hasattr(self, 'deviation'):
+        if self.price.aggregate.price == 0:
             title = f"Aggregate price is $0 on {self.symbol}"
             details = [
                 f"Aggregate: {agg.price:.2f} ± {agg.confidence_interval:.2f} (slot {agg.slot})",

--- a/pyth_observer/events.py
+++ b/pyth_observer/events.py
@@ -185,12 +185,15 @@ class PriceDeviation(PriceValidationEvent):
 
     def is_valid(self) -> bool:
         delta = self.publisher_aggregate.price - self.price.aggregate.price
-        self.deviation = abs(delta / self.price.aggregate.price) * 100
-
-        if (self.price.is_publishing(self.publisher_key) and
-                self.price.is_aggregate_publishing() and
-                self.deviation > self.threshold):
+        if self.price.aggregate.price == 0:
             return False
+        else:
+            self.deviation = abs(delta / self.price.aggregate.price) * 100
+
+            if (self.price.is_publishing(self.publisher_key) and
+                    self.price.is_aggregate_publishing() and
+                    self.deviation > self.threshold):
+                return False
         return True
 
     def get_event_details(self) -> Tuple[str, List[str]]:

--- a/pyth_observer/events.py
+++ b/pyth_observer/events.py
@@ -186,6 +186,7 @@ class PriceDeviation(PriceValidationEvent):
     def is_valid(self) -> bool:
         delta = self.publisher_aggregate.price - self.price.aggregate.price
         if self.price.aggregate.price == 0:
+            #TODO: add another alert that validates whether the aggregate price is close to the truth
             return False
         else:
             self.deviation = abs(delta / self.price.aggregate.price) * 100

--- a/pyth_observer/events.py
+++ b/pyth_observer/events.py
@@ -186,8 +186,8 @@ class PriceDeviation(PriceValidationEvent):
     def is_valid(self) -> bool:
         delta = self.publisher_aggregate.price - self.price.aggregate.price
         if self.price.aggregate.price == 0:
-            #TODO: add another alert that validates whether the aggregate price is close to the truth
-            return False
+            # TODO: add another alert that validates whether the aggregate price is close to the truth
+            return True
         else:
             self.deviation = abs(delta / self.price.aggregate.price) * 100
 
@@ -200,18 +200,11 @@ class PriceDeviation(PriceValidationEvent):
     def get_event_details(self) -> Tuple[str, List[str]]:
         agg = self.price.aggregate
         published = self.publisher_aggregate
-        if self.price.aggregate.price == 0:
-            title = f"Aggregate price is 0 on {self.symbol}"
-            details = [
-                f"Aggregate: {agg.price:.2f} ± {agg.confidence_interval:.2f} (slot {agg.slot})",
-                f"Published:  {published.price:.2f} ± {published.confidence_interval:.2f} (slot {published.slot})",
-            ]
-        else:
-            title = f"{self.publisher_name.upper()} price is {self.deviation:.0f}% off on {self.symbol}"
-            details = [
-                f"Aggregate: {agg.price:.2f} ± {agg.confidence_interval:.2f} (slot {agg.slot})",
-                f"Published:  {published.price:.2f} ± {published.confidence_interval:.2f} (slot {published.slot})",
-            ]
+        title = f"{self.publisher_name.upper()} price is {self.deviation:.0f}% off on {self.symbol}"
+        details = [
+            f"Aggregate: {agg.price:.2f} ± {agg.confidence_interval:.2f} (slot {agg.slot})",
+            f"Published:  {published.price:.2f} ± {published.confidence_interval:.2f} (slot {published.slot})",
+        ]
         return title, details
 
 

--- a/pyth_observer/events.py
+++ b/pyth_observer/events.py
@@ -186,7 +186,6 @@ class PriceDeviation(PriceValidationEvent):
     def is_valid(self) -> bool:
         delta = self.publisher_aggregate.price - self.price.aggregate.price
         if self.price.aggregate.price == 0:
-            self.deviation = 0
             return False
         else:
             self.deviation = abs(delta / self.price.aggregate.price) * 100
@@ -200,12 +199,18 @@ class PriceDeviation(PriceValidationEvent):
     def get_event_details(self) -> Tuple[str, List[str]]:
         agg = self.price.aggregate
         published = self.publisher_aggregate
-
-        title = f"{self.publisher_name.upper()} price is {self.deviation:.0f}% off on {self.symbol}"
-        details = [
-            f"Aggregate: {agg.price:.2f} ± {agg.confidence_interval:.2f} (slot {agg.slot})",
-            f"Published:  {published.price:.2f} ± {published.confidence_interval:.2f} (slot {published.slot})",
-        ]
+        if not hasattr(self, 'deviation'):
+            title = f"Aggregate price is $0 on {self.symbol}"
+            details = [
+                f"Aggregate: {agg.price:.2f} ± {agg.confidence_interval:.2f} (slot {agg.slot})",
+                f"Published:  {published.price:.2f} ± {published.confidence_interval:.2f} (slot {published.slot})",
+            ]
+        else:
+            title = f"{self.publisher_name.upper()} price is {self.deviation:.0f}% off on {self.symbol}"
+            details = [
+                f"Aggregate: {agg.price:.2f} ± {agg.confidence_interval:.2f} (slot {agg.slot})",
+                f"Published:  {published.price:.2f} ± {published.confidence_interval:.2f} (slot {published.slot})",
+            ]
         return title, details
 
 


### PR DESCRIPTION
- program crashes when aggregate price is 0 as it tries to divide delta (publisher aggregate price - aggregate price) by aggregate price
- not sure what's the best way to handle this case but what I did here was to return False if aggregate price is 0 (happy to get suggestions if there are better alternatives)