### PR TITLE
add publisher price feed offline alert

### DIFF
--- a/pyth_observer/calendar.py
+++ b/pyth_observer/calendar.py
@@ -25,9 +25,9 @@ EQUITY_EARLY_HOLIDAYS = [
 
 
 class HolidayCalendar():
-    def is_market_open(self, product, dt):
+    def is_market_open(self, asset_type, dt):
         # equity market
-        if product.attrs['asset_type'] == 'Equity':
+        if asset_type == 'Equity':
             day, date, time = dt.weekday(), dt.date(), dt.time()
             if date in EQUITY_HOLIDAYS or date in EQUITY_EARLY_HOLIDAYS:
                 if date in EQUITY_EARLY_HOLIDAYS and time >= EQUITY_OPEN and time <= EQUITY_EARLY_CLOSE:

--- a/pyth_observer/events.py
+++ b/pyth_observer/events.py
@@ -134,12 +134,6 @@ class BadConfidence(PriceValidationEvent):
         ]
         return title, details
 
-    def is_noisy(self) -> bool:
-        """
-        This event can be very noisy due to publishers using less than or equal to zero confidence interval
-        """
-        return True
-
 
 class ImprobableAggregate(PriceValidationEvent):
     """

--- a/pyth_observer/prices.py
+++ b/pyth_observer/prices.py
@@ -153,9 +153,9 @@ class PriceValidator:
             if self.publisher_key is not None and publisher_key != self.publisher_key:
                 continue
 
-            is_active = price.is_publishing(publisher_key)
+            # is_active = price.is_publishing(publisher_key)
 
-            if is_active and publisher_key in price.quoter_aggregates:
+            if publisher_key in price.quoter_aggregates:
                 for price_validator in price_validators:
                     check = price_validator(
                         publisher_key=publisher_key,

--- a/pyth_observer/prices.py
+++ b/pyth_observer/prices.py
@@ -153,8 +153,6 @@ class PriceValidator:
             if self.publisher_key is not None and publisher_key != self.publisher_key:
                 continue
 
-            # is_active = price.is_publishing(publisher_key)
-
             if publisher_key in price.quoter_aggregates:
                 for price_validator in price_validators:
                     check = price_validator(

--- a/tests/test_price_offline.py
+++ b/tests/test_price_offline.py
@@ -1,0 +1,52 @@
+from pyth_observer.events import PriceFeedOffline
+from pythclient.pythaccounts import PythPriceInfo, PythPriceStatus
+
+
+class MockPythProductAccount:
+    def __init__(self, product_attrs):
+        self.attrs = product_attrs
+
+
+class MockPriceAccount:
+    def __init__(self, current_slot, aggregate_price_info_slot, aggregate_price_info_status, product_attrs):
+        self.slot = current_slot
+        self.aggregate_price_info = PythPriceInfo(0, 0, aggregate_price_info_status, aggregate_price_info_slot, 0)
+        self.product = MockPythProductAccount(product_attrs)
+
+
+def check_price_offline(current_slot, aggregate_price_info_slot, aggregate_price_info_status, product_attrs, expected_str):
+    pa = MockPriceAccount(current_slot, aggregate_price_info_slot, aggregate_price_info_status, product_attrs)
+    network = "mainnet"
+    symbol = "ZZZT"
+
+    t = PriceFeedOffline(None, 0, pa, network, symbol)
+    result = t.is_valid()
+
+    if not result:
+        title, details = t.get_event_details()
+        print(title, details)
+
+    if expected_str:
+        assert not result
+        assert title == expected_str
+    else:
+        assert result
+
+
+def test_price_offline():
+    trading = PythPriceStatus.TRADING
+    unknown = PythPriceStatus.UNKNOWN
+
+    product_attrs = {'asset_type': 'Crypto', 'symbol': 'Crypto.BCH/USD', 'quote_currency': 'USD',
+                     'description': 'BCH/USD', 'generic_symbol': 'BCHUSD', 'base': 'BCH'}
+
+    # aggregate slot > 25 behind current latest slot
+    check_price_offline(27, 1, trading, product_attrs,
+                        "ZZZT price feed is offline (has not updated its price in > 25 slots OR status is unknown)")
+
+    # aggregate trading status is != trading
+    check_price_offline(1, 1, unknown, product_attrs,
+                        "ZZZT price feed is offline (has not updated its price in > 25 slots OR status is unknown)")
+
+    # no event if aggregate slot is <= 25 current latest slot and status is trading
+    check_price_offline(1, 1, trading, product_attrs, None)

--- a/tests/test_publisher_price_offline.py
+++ b/tests/test_publisher_price_offline.py
@@ -1,0 +1,62 @@
+from pyth_observer.events import PublisherPriceFeedOffline
+from pythclient.pythaccounts import PythPriceInfo, PythPriceStatus
+from pyth_observer.prices import Price
+
+
+def check_publisher_price_offline(current_slot, publisher_slot, publisher_status, product_attrs, expected_str):
+    network = "mainnet"
+    symbol = "ZZZT"
+    publisher_key = "pubkey"
+
+    price = Price(current_slot, product_attrs=product_attrs, publishers={publisher_key: "pubname"})
+
+    quoter_aggregate = PythPriceInfo(
+        raw_price=0,
+        raw_confidence_interval=1,
+        price_status=publisher_status,
+        slot=5,
+        exponent=-1
+    )
+    price.quoter_aggregates[publisher_key] = quoter_aggregate
+
+    publisher_latest = PythPriceInfo(
+        raw_price=0,
+        raw_confidence_interval=1,
+        price_status=publisher_status,
+        slot=publisher_slot,
+        exponent=-1
+    )
+    price.quoters[publisher_key] = publisher_latest
+
+    validation = PublisherPriceFeedOffline(publisher_key, price, None, network, symbol)
+    # Set the firing threshold to 10% for testing
+    result = validation.is_valid()
+
+    if not result:
+        title, details = validation.get_event_details()
+        print(title, details)
+
+    if expected_str:
+        assert not result
+        assert title == expected_str
+    else:
+        assert result
+
+
+def test_publisher_price_offline():
+    trading = PythPriceStatus.TRADING
+    unknown = PythPriceStatus.UNKNOWN
+
+    product_attrs = {'asset_type': 'Crypto', 'symbol': 'Crypto.BCH/USD', 'quote_currency': 'USD',
+                     'description': 'BCH/USD', 'generic_symbol': 'BCHUSD', 'base': 'BCH'}
+
+    # publisher slot > 25 behind current latest slot
+    check_publisher_price_offline(27, 1, trading, product_attrs,
+                                  "pubkey ZZZT price feed is offline (has not updated its price in > 25 slots OR status is unknown)")
+
+    # publisher trading status is != trading
+    check_publisher_price_offline(1, 1, unknown, product_attrs,
+                                  "pubkey ZZZT price feed is offline (has not updated its price in > 25 slots OR status is unknown)")
+
+    # no event if publisher slot is <= 25 current latest slot and status is trading
+    check_publisher_price_offline(1, 1, trading, product_attrs, None)


### PR DESCRIPTION
https://app.clickup.com/t/1zhfeqy

currently, the program checks if the price account is publishing (status == TRADING, conf interval != 0, slot_diff < 25) before running the individual checks in each events, however this prevents the alert from firing for individual publisher price feed if they went offline (status = UNKNOWN or slot_diff < 25) as the checks don't get run

hence, moving the checks into individual events

appreciate any tips for better alternatives if there are any