### PR TITLE
Less noisy feed offline alert

### DIFF
--- a/observer.py
+++ b/observer.py
@@ -110,6 +110,7 @@ async def main(args):
                         price_account_errors = validators[symbol].verify_price_account(
                             price_account=price_account,
                             coingecko_price=coingecko_price,
+                            include_noisy=args.include_noisy_alerts,
                         )
                         if price_account_errors:
                             errors.extend(price_account_errors)

--- a/pyth_observer/events.py
+++ b/pyth_observer/events.py
@@ -75,6 +75,10 @@ class ValidationEvent:
         return "", []
 
     def is_valid(self) -> bool:
+        """
+        Return True if the invariant checked by this event is satisfied.
+        Return False if the event should trigger a notification.
+        """
         raise NotImplementedError
 
     def is_noisy(self) -> bool:

--- a/pyth_observer/events.py
+++ b/pyth_observer/events.py
@@ -315,6 +315,58 @@ class PriceFeedOffline(PriceAccountValidationEvent):
         ]
         return title, details
 
+    def is_noisy(self) -> bool:
+        """
+        This event can be very noisy because several of our price feeds are flaky.
+        """
+        return True
+
+
+class LongDurationPriceFeedOffline(PriceAccountValidationEvent):
+    """
+    This alert fires when a price feed should be updating, but isn't.
+    It alerts when a price hasn't updated in > PYTH_OBSERVER_STOP_PUBLISHING_MIN_SLOTS (default 600) slots.
+    This alert requires a longer offline duration than PriceFeedOffline.
+    """
+    error_code: str = "long-price-feed-offline"
+    threshold_slots: int = int(os.environ.get("PYTH_OBSERVER_STOP_PUBLISHING_MIN_SLOTS", 600))
+
+    def is_valid(self) -> bool:
+        # The aggregate's slot field updates even when the status=UNKNOWN, but each publisher's slot
+        # only updates when they are included in the aggregate. Therefore, look at the last publish slot
+        # for each publisher to determine the last slot in which a sufficient number of publishers were active.
+        # This check has perfect precision but imperfect recall.  If the alert fires, the price feed has
+        # definitely been offline for the configured duration. However, there are cases when it should fire but
+        # doesn't. For example, it will not fire if there are 3 publishers publishing
+        # every 100 slots, but spaced so that the 3 are never active at the same time.
+        # However, this situation is unlikely.
+        active_publishers = self._get_num_active_publishers()
+
+        if active_publishers < self.price_account.min_publishers:
+            market_open = calendar.is_market_open(
+                self.price_account.product.attrs['asset_type'], datetime.datetime.now(tz=TZ))
+            if market_open:
+                return False
+        return True
+
+    def _get_num_active_publishers(self) -> int:
+        active_publishers = 0
+        for component in self.price_account.price_components:
+            stopped_slots = self.price_account.last_slot - component.last_aggregate_price_info.slot
+            if stopped_slots < self.threshold_slots:
+                active_publishers += 1
+
+        return active_publishers
+
+    def get_event_details(self) -> Tuple[str, List[str]]:
+        title = f"{self.symbol} price feed is offline (no update for > {self.threshold_slots} slots)"
+        details = [
+            # f"Last Updated Slot: {self.price_account.aggregate_price_info.slot}",
+            f"Current Slot: {self.price_account.slot}",
+            f"Status: {self.price_account.aggregate_price_info.price_status}"
+        ]
+        return title, details
+
 
 class NegativeTWAP(PriceAccountValidationEvent):
     error_code: str = "negative-twap"

--- a/pyth_observer/events.py
+++ b/pyth_observer/events.py
@@ -363,9 +363,9 @@ class LongDurationPriceFeedOffline(PriceAccountValidationEvent):
         return active_publishers
 
     def get_event_details(self) -> Tuple[str, List[str]]:
+        # There's not a good way to get the last time the feed updated, unfortunately.
         title = f"{self.symbol} price feed is offline (no update for > {self.threshold_slots} slots)"
         details = [
-            # f"Last Updated Slot: {self.price_account.aggregate_price_info.slot}",
             f"Current Slot: {self.price_account.slot}",
             f"Status: {self.price_account.aggregate_price_info.price_status}"
         ]

--- a/pyth_observer/prices.py
+++ b/pyth_observer/prices.py
@@ -136,6 +136,7 @@ class PriceValidator:
         self,
         price_account: PythPriceAccount,
         coingecko_price=None,
+        include_noisy=False,
     ) -> Optional[List[ValidationEvent]]:
         self.update_slot(price_account.slot)
         self.update_coingecko_price(coingecko_price)
@@ -149,6 +150,8 @@ class PriceValidator:
                 symbol=self.symbol,
                 coingecko_price=self.coingecko_price,
             )
+            if include_noisy is False and check.is_noisy():
+                continue
             if check.is_valid() is False:
                 self.update_events(check)
                 errors.append(check)


### PR DESCRIPTION
I messed around with the existing alerts and configuration, and it seems like many of our price feeds flash offline for short periods then come back online. Obviously that situation isn't great and we should fix it. However, it also means that the straightforward price feed down alert is noisy and largely useless.

This PR adds another feed offline check that only alerts if the feed has been down for 600 slots. The check isn't perfect (see code comment), but I think it's worthwhile to have in the short run.

I also marked the PriceFeedOffline alert as noisy. Once we fix the flaky price feeds we can start using PriceFeedOffline.