### PR TITLE
Expose publisher status gauge

### DIFF
--- a/observer.py
+++ b/observer.py
@@ -163,6 +163,7 @@ async def main(args):
                                     error_code=error.error_code,
                                 ).set(1)
                         else:
+                            continue
                             prom_price_account_errors.labels(
                                 symbol=symbol,
                                 error_code="",
@@ -178,6 +179,7 @@ async def main(args):
                                         error_code=error.error_code,
                                     ).set(1)
                             else:
+                                continue
                                 prom_publisher_price_errors.labels(
                                     symbol=symbol,
                                     publisher=publisher,

--- a/pyth_observer/main.py
+++ b/pyth_observer/main.py
@@ -1,0 +1,41 @@
+import asyncio
+
+from asyncio_throttle import Throttler
+from loguru import logger
+from pythclient.pythclient import PythClient
+
+from pyth_observer import get_key, get_solana_urls
+from pyth_observer.price_account_observer import PriceAccountObserver
+from pyth_observer.publisher_price_observer import PublisherPriceObserver
+
+
+async def main():
+    network = "testnet"
+    program_key = get_key(network=network, type="program", version="v2")
+    mapping_key = get_key(network=network, type="mapping", version="v2")
+    http_url, ws_url = get_solana_urls(network=network)
+
+    throttler = Throttler(rate_limit=6, period=3)
+
+    async with PythClient(
+        solana_endpoint=http_url,
+        solana_ws_endpoint=ws_url,
+        first_mapping_account_key=mapping_key,
+        program_key=program_key,
+    ) as client:
+        observers = []
+
+        for product in await client.get_products():
+            async with throttler:
+                price_accounts = await product.get_prices()
+
+            for _, price_account in price_accounts.items():
+                observers.append(PriceAccountObserver(client, throttler, price_account).run())
+                observers.append(PublisherPriceObserver(client, throttler, price_account).run())
+
+        await asyncio.gather(*observers)
+
+
+
+
+asyncio.run(main())

--- a/pyth_observer/price_account_observer.py
+++ b/pyth_observer/price_account_observer.py
@@ -1,0 +1,31 @@
+import asyncio
+
+from asyncio_throttle import Throttler
+from loguru import logger
+from pythclient.pythclient import PythClient, PythPriceAccount
+
+from pyth_observer.coingecko import get_coingecko_prices
+from pyth_observer.prices import PriceValidator
+
+
+class PriceAccountObserver:
+  def __init__(self, client: PythClient, throttler: Throttler, price_account: PythPriceAccount):
+    self.client = client
+    self.throttler = throttler
+    self.price_account = price_account
+
+  async def run(self) -> None:
+    while True:
+      logger.debug(f"Observing: {self.price_account.product.symbol}")
+
+      coingecko_price = await get_coingecko_prices(self.price_account.product.attrs["base"])
+
+      events = PriceValidator(
+          symbol=self.price_account.product.symbol,
+          coingecko_price=coingecko_price.get(self.price_account.product.attrs["base"]),
+      ).verify_price_account(self.price_account)
+
+      if events:
+        logger.warning(events)
+
+      await asyncio.sleep(30)

--- a/pyth_observer/publisher_price_observer.py
+++ b/pyth_observer/publisher_price_observer.py
@@ -1,0 +1,10 @@
+
+class PublisherPriceObserver:
+  def __init__(self, client: PythClient, throttler: Throttler, price_account: PythPriceAccount):
+    self.client = client
+    self.throttler = throttler
+    self.price_account = price_account
+
+  async def run(self) -> None:
+    while True:
+      continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,14 @@
+aiocoingecko==1.0.0
 aiohttp<4.0.0a1
+asyncio-throttle==1.0.2
 dnspython
 loguru
 pytz
 pycoingecko==2.2.0
 prometheus-client==0.13.1
 
-# Testing
+# Dev & Test
+mypy==0.942
 pytest
 pythclient==0.0.2
 typing-extensions==3.10.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,10 @@ dnspython
 loguru
 pytz
 pycoingecko==2.2.0
+prometheus-client==0.13.1
 
 # Testing
 pytest
 pythclient==0.0.2
-prometheus-client==0.12.0
 typing-extensions==3.10.0.2
 pytest-mock


### PR DESCRIPTION
This adds a new Prometheus gauge to keep track of the error code for each price account and publisher. We use the empty string error code to communicate that the publisher/symbol pair is in a healthy status. There is a separate time series for each error code so we can have error-specific alerts. We can combine multiple series using queries.