### PR TITLE
Pluggable alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+---
+# Continuous testing using the github actions
+#
+
+name: CI
+
+# yamllint disable-line rule:truthy
+on:
+    push:
+    schedule:
+        - cron: '0 0 1 * *'
+
+jobs:
+    lint:
+        name: make lint
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Install Dependencies
+              run: |
+                sudo apt update
+                sudo apt install python3-venv flake8 yamllint
+            - name: Run tests
+              run: make lint
+
+    test:
+        name: make test and coverage report
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Install Dependencies
+              run: |
+                sudo apt update
+                sudo apt install python3-venv python3-pytest
+            - name: Run tests
+              run: make test
+
+            - name: Upload coverage report
+              uses: actions/upload-artifact@v2
+              with:
+                name: htmlcov
+                path: htmlcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
                 sudo apt update
                 sudo apt install python3-venv python3-pytest
             - name: Run tests
-              run: make test
+              run: make cover
 
             - name: Upload coverage report
               uses: actions/upload-artifact@v2

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,5 +1,7 @@
+---
 name: Build Docker image
 
+# yamllint disable-line rule:truthy
 on:
   push:
     branches:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ publishers.json
 **/__pycache__
 
 .DS_Store
+.coverage

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+#
+#
+#
+
+all:
+	echo No default target - try ve, test, lint, run
+	false
+
+COVER_PERCENT:=60
+
+# FIXME:
+# - depends on python > 3.6 (bad news for RHEL7 /and/ RHEL8)
+# - Add a check for correct version and fail fast
+
+ve: ve/pyvenv.cfg
+ve/pyvenv.cfg: requirements.txt
+	python3 -m venv ve
+	. ve/bin/activate; pip install -r requirements.txt
+
+test: ve
+	. ve/bin/activate; pytest
+
+cover: ve
+	. ve/bin/activate; pytest \
+	    --cov=pyth_observer \
+	    --cov-report=html \
+	    --cov-report=term \
+	    --cov-fail-under=$(COVER_PERCENT)
+
+lint: lint.python
+#lint: lint.yaml - argh, RHEL is too old to do this by default
+
+lint.python: ve
+	. ve/bin/activate; flake8 observer.py pyth_observer/
+
+lint.yaml:
+	yamllint .
+
+run: ve
+	. ve/bin/activate; python3 ./observer.py -l debug --network devnet
+
+clean:
+	rm -rf ve htmlcov

--- a/README.md
+++ b/README.md
@@ -51,3 +51,65 @@ To send alerts to slack, you need to create an app and get the [incoming webhook
 ```shell
 export PYTH_OBSERVER_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0GPR2P4K/B02J164R5MF/XYZ123LMAOZOMGBBQWTF
 ```
+
+## Build automation
+
+To help with both automated builds and documenting the exact build process,
+there is a Makefile and a github actions Continuous Integration job.
+
+The github action will run on each commit pushed to confirm that all tests
+are passing and there are no style-guide issues.
+
+The Makefile provides several convenience functions:
+
+| **Command**   | **Description**                                            |
+| ------------- | ---------------------------------------------------------- |
+| `make lint`   | Checks the code for style-guide and syntax issues          |
+| `make test`   | Runs the internal unit test suite                          |
+| `make cover`  | Runs the test suite, but also generates a report of the code coverage |
+| `make run`    | Runs the pyth observer on devnet, logging to stderr        |
+
+## Notification modules
+
+The pyth observer ships with two sample notification modules, one for logging
+to stderr and one for sending to slack.  One or more instances of the
+available notifier modules can be selected from the commandline using the
+`--notifier`` commandline arg.
+
+The default is to use the `logger` module unless there is a
+`--slack-webhook-url`, in which case it defaults to using the `slack` module.
+
+More than one notification module can be enabled simultaneously and each
+module can loaded multiple times (useful if you want to notify more than one
+slack channel)
+
+| **Notifier Module**               | **Module Args**                                             |
+| --------------------------------- | ----------------------------------------------------------- |
+| `pyth_observer.notifiers.logger`  | none                                                        |
+| `pyth_observer.notifiers.slack`   | The URL of the Slack incoming webhook for this notification |
+
+The args to pass to the notifier module are separated from the module name with
+an equals ("=") sign
+
+e.g:
+```shell
+./observer.py --network=testnet --notifier=pyth_observer.notifiers.slack=https://hooks.slack.com/services/T0GPR2P4K/B02J164R5MF/XYZ123LMAOZOMGBBQWTF
+```
+
+## Writing custom notifiers
+
+The pyth observer is intended to be flexible and allow you to integrate with
+any monitoring, alerting or logging system you might be using.
+
+The name of the notifier that is passed to the ``--notifier`` arg is a full
+python module path, which is then loaded using the normal Python search
+process.  The two included implementations can be used as a starting points
+for writing custom notifiers.
+
+Each module has a `Notifier` class inside it, which is instantiated for each
+separate mention from a ``--notifier`` arg - with any args passed on the
+command line passed into the object initializer.
+
+Adding a new `Foo` notifier can be as simple as dropping a file ``Foo.py``
+into this directory and then adding ``--notifier=Foo=optionalargs`` to the
+commandline you start ``./observer.py`` with.

--- a/observer.py
+++ b/observer.py
@@ -222,7 +222,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "--ignore",
         nargs="+",
-        help="List of symbols and / or events to ignore. For e.g. 'Crypto.ORCA/USD' to ignore all ORCA alerts and 'FX.*/price-feed-offline' to ignore all price-feed-offline alerts for all FX pairs",
+        help="List of symbols and / or events to ignore. "
+             "For e.g. 'Crypto.ORCA/USD' to ignore all ORCA alerts and "
+             "'FX.*/price-feed-offline' to ignore all price-feed-offline "
+             "alerts for all FX pairs",
     )
     args = parser.parse_args()
 

--- a/pyth_observer/notifiers/logger.py
+++ b/pyth_observer/notifiers/logger.py
@@ -1,0 +1,23 @@
+#
+# A simple notifier that just logs to the logging framework
+
+from .notification import NotificationBase
+
+from loguru import logger
+
+
+class Notifier(NotificationBase):
+    """
+    Do nothing notification, just log to stderr
+    """
+
+    async def notify(self, error):
+        title, details = error.get_event_details()
+
+        logger.error(
+            "{} on {}: {} - {}",
+            error.error_code,
+            error.network,
+            title,
+            ", ".join(details),
+        )

--- a/pyth_observer/notifiers/notification.py
+++ b/pyth_observer/notifiers/notification.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import datetime
+
+import pytz
+
+
+class NotificationBase:
+    def get_footer(self, error):
+        """
+        A footer for longer form messages
+        """
+        now = datetime.datetime.now(tz=pytz.UTC)
+        nowtime = now.isoformat(sep=" ", timespec="seconds")
+        return [
+            f"Network: {error.network}",
+            f"Last seen {nowtime}",
+        ]
+
+    def __init__(self, param):
+        if param is not None:
+            raise ValueError("Basic Notification takes no parameters")
+
+    async def notify(self, error) -> None:
+        raise NotImplementedError

--- a/pyth_observer/notifiers/slack.py
+++ b/pyth_observer/notifiers/slack.py
@@ -1,46 +1,14 @@
-#!/usr/bin/env python3
-import datetime
+# Notify slack via a webhook url
+#
 
-import pytz
+from .notification import NotificationBase
+
 import aiohttp
 
 from loguru import logger
 
 
-class Notification:
-    def get_footer(self, error):
-        """
-        A footer for longer form messages
-        """
-        now = datetime.datetime.now(tz=pytz.UTC)
-        nowtime = now.isoformat(sep=" ", timespec="seconds")
-        return [
-            f"Network: {error.network}",
-            f"Last seen {nowtime}",
-        ]
-
-    async def notify(self, error) -> None:
-        raise NotImplementedError
-
-
-class LoggerNotification(Notification):
-    """
-    Do nothing notification, just log to stderr
-    """
-
-    async def notify(self, error):
-        title, details = error.get_event_details()
-
-        logger.error(
-            "{} on {}: {} - {}",
-            error.error_code,
-            error.network,
-            title,
-            ", ".join(details),
-        )
-
-
-class SlackNotification(Notification):
+class Notifier(NotificationBase):
     """
     Notify slack via a webhook url
     """

--- a/pyth_observer/prices.py
+++ b/pyth_observer/prices.py
@@ -11,8 +11,6 @@ from pythclient.pythaccounts import (
     PythPriceInfo,
 )
 
-from pyth_observer import coingecko
-
 from .notification import (
     SlackNotification,
     LoggerNotification,

--- a/pyth_observer/prices.py
+++ b/pyth_observer/prices.py
@@ -11,11 +11,6 @@ from pythclient.pythaccounts import (
     PythPriceInfo,
 )
 
-from .notification import (
-    SlackNotification,
-    LoggerNotification,
-)
-
 from .events import (
     ValidationEvent,
     price_validators,
@@ -187,19 +182,14 @@ class PriceValidator:
                         errors.append(check)
         return errors
 
-    async def notify(self, events, **kwargs):
+    async def notify(self, events, notifiers, **kwargs):
         """
         Send notifications for erroneous events.
 
         A few useful kwargs:
 
-            slack_webhook_url: for alerting via slack
             notification_mins: number of minutes between sending nearly identical alerts.
         """
-        if kwargs.get("slack_webhook_url"):
-            notifier = SlackNotification(kwargs["slack_webhook_url"])
-        else:
-            notifier = LoggerNotification()
 
         for event in events:
             event_data = self.events[event.unique_id]
@@ -227,4 +217,6 @@ class PriceValidator:
                 "skipped": 0,
                 "last_notified": datetime.now(),
             })
-            await notifier.notify(event)
+
+            for notifier in notifiers:
+                await notifier.notify(event)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ pythclient==0.0.2
 prometheus-client==0.12.0
 typing-extensions==3.10.0.2
 pytest-mock
+flake8
+pytest-cov


### PR DESCRIPTION
For our internal alerting infrastructure, we wanted to have more ways of alerting than simply using a slack channel.  As part of implementing our private alerting system, we extended pyth-observer to allow simple plugging in of new alerting modules.

Also included here are a github action for Continuous Integration job and some Makefile targets for the basic test and run steps.