### PR TITLE
Catch and log HTTPError exceptions accessing CoinGecko API.

### DIFF
--- a/pyth_observer/coingecko.py
+++ b/pyth_observer/coingecko.py
@@ -1,7 +1,9 @@
 import json
 import os
 
+from loguru import logger
 from pycoingecko import CoinGeckoAPI
+from requests.exceptions import HTTPError
 
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -22,7 +24,13 @@ api_to_symbol_mapping = {symbol_to_id_mapping[x]['api']: x for x in symbol_to_id
 
 def get_coingecko_prices(symbols):
     ids = [symbol_to_id_mapping[x]["api"] for x in symbol_to_id_mapping if x in symbols]
-    prices = cg.get_price(ids=ids, vs_currencies='usd')
+    try:
+        prices = cg.get_price(ids=ids, vs_currencies='usd')
+    except HTTPError as exc:
+        logger.exception(exc)
+        logger.error("CoinGecko API call failed - CoinGecko price comparisons not available.")
+        prices = {}
+
     # remap to symbol -> prices
     prices_mapping = {api_to_symbol_mapping[x]: prices[x] for x in prices}
     return prices_mapping


### PR DESCRIPTION
If CoinGecko's API is down we should continue with other checks, rather than exiting.

We could try to do something more sophisticated, like cache the last known prices for some reasonable TTL, but this is just a minimal "don't fall over" fix.