### PR TITLE
Update prometheus metrics

### DIFF
--- a/observer.py
+++ b/observer.py
@@ -197,7 +197,7 @@ async def main(args):
                             if e.error_code not in code_to_errors:
                                 code_to_errors[e] = []
 
-                            title, details = e.get_event_details()[0]
+                            title, details = e.get_event_details()
                             details_joined = '\n'.join(details)
                             formatted = f"{title}\n{details_joined}"
                             code_to_errors[e] = [formatted]

--- a/observer.py
+++ b/observer.py
@@ -192,8 +192,17 @@ async def main(args):
                     )
 
                     if args.enable_prometheus:
+                        code_to_errors = {}
                         for e in filtered_errors:
-                            num_alerts_counter.labels(symbol=symbol).inc(exemplar={"error_code": e.error_code})
+                            if e.error_code not in code_to_errors:
+                                code_to_errors[e] = []
+
+                            title, details = e.get_event_details()[0]
+                            formatted = f"{title}\n{'\n''.join(details)}"
+                            code_to_errors[e] = [formatted]
+
+                        exemplar = dict([(k, "---\n".join(v)) for k,v in code_to_errors.items()])
+                        num_alerts_counter.labels(symbol=symbol).inc(len(filtered_errors), exemplar=exemplar)
                         if len(filtered_errors) == 0:
                             num_alerts_counter.labels(symbol=symbol).inc(0)
 

--- a/observer.py
+++ b/observer.py
@@ -203,7 +203,7 @@ async def main(args):
 
                     if args.enable_prometheus:
                         exemplar = dict([(e.error_code, "true") for e in filtered_errors])
-                        num_alerts_gauge.labels(symbol=symbol).set(len(filtered_errors), exemplar=exemplar)
+                        num_alerts_gauge.labels(symbol=symbol).set(len(filtered_errors), exemplar)
 
                     if product.attrs["asset_type"] == "Crypto":
                         # check if coingecko price exists

--- a/observer.py
+++ b/observer.py
@@ -198,7 +198,7 @@ async def main(args):
                                 code_to_errors[e] = []
 
                             title, details = e.get_event_details()[0]
-                            details_joined = '\n''.join(details)
+                            details_joined = '\n'.join(details)
                             formatted = f"{title}\n{details_joined}"
                             code_to_errors[e] = [formatted]
 

--- a/observer.py
+++ b/observer.py
@@ -198,7 +198,8 @@ async def main(args):
                                 code_to_errors[e] = []
 
                             title, details = e.get_event_details()[0]
-                            formatted = f"{title}\n{'\n''.join(details)}"
+                            details_joined = '\n''.join(details)
+                            formatted = f"{title}\n{details_joined}"
                             code_to_errors[e] = [formatted]
 
                         exemplar = dict([(k, "---\n".join(v)) for k,v in code_to_errors.items()])


### PR DESCRIPTION
This exposes a counter of errors on each symbol with an exemplar showing the full text of the alerts that fired. Note that the exemplars only show up if you pass an http header "Accept: application/openmetrics-text" to toggle openmetrics format.