### PR TITLE
Fix the cross chain api change problem

### DIFF
--- a/pyth_observer/crosschain.py
+++ b/pyth_observer/crosschain.py
@@ -32,10 +32,9 @@ class CrosschainPriceObserver:
         # return a dictionary of id -> {price, conf, expo} for fast lookup
         return {
             data["id"]: {
-                "price": int(data["price"]) * 10 ** data["expo"],
-                "conf": int(data["conf"]) * 10 ** data["expo"],
-                "publish_time": data["publish_time"],
-                "prev_publish_time": data["prev_publish_time"],
+                "price": int(data["price"]["price"]) * 10 ** data["price"]["expo"],
+                "conf": int(data["price"]["conf"]) * 10 ** data["price"]["expo"],
+                "publish_time": data["price"]["publish_time"],
             }
             for data in latest_price_feeds
         }


### PR DESCRIPTION
Pyth observer is currently down because the newly deployed price service has changed the schema of its returned price feeds. This PR uses the new schema ([link](https://github.com/pyth-network/pyth-sdk-js/blob/main/src/schemas/price_feed.json)). An example output is:

```json
[{"ema_price":{"conf":"385612290","expo":-8,"price":"2008445240000","publish_time":1665079368},"id":"e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43","price":{"conf":"365827995","expo":-8,"price":"2008064619250","publish_time":1665079368}}]
```

The prev_publish_price is not used anywhere. I double checked by reading the usage on `events.py` and searching for `prev_publish_price` on the codebase (as it's a dictionary any usage explicitly use it)