### PR TITLE
Fix aggregate confidence interval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "pyth-observer"
-version = "0.1.5"
+version = "0.1.6"
 description = "Alerts and stuff"
 authors = []
 readme = "README.md"

--- a/pyth_observer/__init__.py
+++ b/pyth_observer/__init__.py
@@ -135,7 +135,7 @@ class Observer:
                                 symbol=product.attrs["symbol"],
                                 public_key=component.publisher_key,
                                 confidence_interval=component.latest_price_info.confidence_interval,
-                                confidence_interval_aggregate=component.last_aggregate_price_info.confidence_interval,
+                                confidence_interval_aggregate=price_account.aggregate_price_info.confidence_interval,
                                 price=component.latest_price_info.price,
                                 price_aggregate=price_account.aggregate_price_info.price,
                                 slot=component.latest_price_info.pub_slot,


### PR DESCRIPTION
Fix a bug where aggregate confidence interval is set to be the component confidence interval instead