### PR TITLE
Improve datadog aggregate key for publisher checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "pyth-observer"
-version = "0.1.6"
+version = "0.1.7"
 description = "Alerts and stuff"
 authors = []
 readme = "README.md"

--- a/pyth_observer/event.py
+++ b/pyth_observer/event.py
@@ -37,8 +37,12 @@ class DatadogEvent(Event):
         # generating the error title/message.
         text = self.check.error_message()
 
+        # An example is: PriceFeedOfflineCheck-Crypto.AAVE/USD
         aggregation_key = f"{self.check.__class__.__name__}-{self.check.state().symbol}"
+
         if self.check.__class__.__bases__ == (PublisherCheck,):
+            # Add publisher key to the aggregation key to separate different faulty publishers
+            # An example would be: PublisherPriceCheck-Crypto.AAVE/USD-9TvAYCUkGajRXs....
             aggregation_key += "-" + self.check.state().public_key
 
         event = DatadogAPIEvent(

--- a/pyth_observer/event.py
+++ b/pyth_observer/event.py
@@ -11,6 +11,7 @@ from datadog_api_client.v1.model.event_create_request import (
 from loguru import logger
 
 from pyth_observer.check import Check
+from pyth_observer.check.publisher import PublisherCheck
 
 
 class Context(TypedDict):
@@ -35,8 +36,13 @@ class DatadogEvent(Event):
         # Publisher checks expect the key -> name mapping of publishers when
         # generating the error title/message.
         text = self.check.error_message()
+
+        aggregation_key = f"{self.check.__class__.__name__}-{self.check.state().symbol}"
+        if self.check.__class__.__bases__ == (PublisherCheck,):
+            aggregation_key += "-" + self.check.state().public_key
+
         event = DatadogAPIEvent(
-            aggregation_key=f"{self.check.__class__.__name__}-{self.check.state().symbol}",
+            aggregation_key=aggregation_key,
             title=text.split("\n")[0],
             text=text,
             tags=[


### PR DESCRIPTION
This PR includes publisher key in the aggregate key of a PublisherCheck. It allows us to mute specific publisher instead of muting all the entire check from datadog (which is not good)