### PR TITLE
Make crosschain price optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "pyth-observer"
-version = "0.1.8"
+version = "0.1.9"
 description = "Alerts and stuff"
 authors = []
 readme = "README.md"

--- a/pyth_observer/__init__.py
+++ b/pyth_observer/__init__.py
@@ -89,9 +89,9 @@ class Observer:
                 # for each publisher).
                 states = []
                 price_accounts = await self.get_pyth_prices(product)
-                crosschain_price = crosschain_prices[
-                    b58decode(product.first_price_account_key.key).hex()
-                ]
+                crosschain_price = crosschain_prices.get(
+                    b58decode(product.first_price_account_key.key).hex(), None
+                )
 
                 for _, price_account in price_accounts.items():
                     if not price_account.aggregate_price_status:


### PR DESCRIPTION
There are some feeds on mainnet that are not available on pythnet and hence not available on price service. This is causing the mainnet observer to crash. This code makes the crosschain price optional as fix. This will also handle the scenario that a price on Pythnet does not reach the price server properly.