### PR TITLE
Fix crosschain staleness check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV \
     POETRY_NO_INTERACTION=1
 
 # Install Poetry - respects $POETRY_VERSION & $POETRY_HOME
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python
+RUN curl -sSL https://install.python-poetry.org | python
 ENV PATH="$POETRY_HOME/bin:$PATH"
 
 WORKDIR $APP_PATH

--- a/pyth_observer/check/price_feed.py
+++ b/pyth_observer/check/price_feed.py
@@ -211,7 +211,6 @@ class PriceFeedCrossChainOnlineCheck(PriceFeedCheck):
         return False
 
     def error_message(self) -> str:
-        print(self.__state.crosschain_price)
         if self.__state.crosschain_price:
             publish_time = arrow.get(self.__state.crosschain_price["publish_time"])
         else:

--- a/pyth_observer/check/price_feed.py
+++ b/pyth_observer/check/price_feed.py
@@ -198,7 +198,10 @@ class PriceFeedCrossChainOnlineCheck(PriceFeedCheck):
         if not self.__state.crosschain_price["publish_time"]:
             return True
 
-        staleness = int(time.time()) - self.__state.crosschain_price["publish_time"]
+        staleness = (
+            self.__state.crosschain_price["snapshot_time"]
+            - self.__state.crosschain_price["publish_time"]
+        )
 
         # Pass if current staleness is less than `max_staleness`
         if staleness < self.__max_staleness:
@@ -208,6 +211,7 @@ class PriceFeedCrossChainOnlineCheck(PriceFeedCheck):
         return False
 
     def error_message(self) -> str:
+        print(self.__state.crosschain_price)
         if self.__state.crosschain_price:
             publish_time = arrow.get(self.__state.crosschain_price["publish_time"])
         else:

--- a/pyth_observer/crosschain.py
+++ b/pyth_observer/crosschain.py
@@ -1,3 +1,4 @@
+import time
 from typing import Dict, TypedDict
 
 import requests
@@ -11,6 +12,7 @@ class CrosschainPrice(TypedDict):
     price: float
     conf: float
     publish_time: int  # UNIX timestamp
+    snapshot_time: int  # UNIX timestamp
 
 
 class CrosschainPriceObserver:
@@ -51,6 +53,7 @@ class CrosschainPriceObserver:
                 "price": int(data["price"]["price"]) * 10 ** data["price"]["expo"],
                 "conf": int(data["price"]["conf"]) * 10 ** data["price"]["expo"],
                 "publish_time": data["price"]["publish_time"],
+                "snapshot_time": int(time.time()),
             }
             for data in price_feeds
         }

--- a/tests/test_checks_price_feed.py
+++ b/tests/test_checks_price_feed.py
@@ -16,7 +16,12 @@ def test_price_feed_offline_check():
         confidence_interval_aggregate=10.0,
         coingecko_price=1005.0,
         coingecko_update=0,
-        crosschain_price={"price": 1003.0, "conf": 10.0, "publish_time": 123},
+        crosschain_price={
+            "price": 1003.0,
+            "conf": 10.0,
+            "publish_time": 123,
+            "snapshot_time": 123,
+        },
     )
 
     assert PriceFeedOfflineCheck(


### PR DESCRIPTION
This fixes a bug where crosschain prices are considered stale because a long time passes between fetching the prices from the price service and checking the staleness. 

This bug also exists on the current pythnet deployment. I think the reason it went undetected is that the main loop is faster on pythnet because the rpc node is faster.
