### PR TITLE
fix: manual encode array params for hermes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "pyth-observer"
-version = "0.1.10"
+version = "0.1.12"
 description = "Alerts and stuff"
 authors = []
 readme = "README.md"

--- a/pyth_observer/crosschain.py
+++ b/pyth_observer/crosschain.py
@@ -42,8 +42,11 @@ class CrosschainPriceObserver:
             for ids in chunked(price_feed_ids, 25):
                 price_feeds_url = f"{self.url}/api/latest_price_feeds"
 
+                # aiohttp does not support encoding array params using PHP-style `ids=[]`
+                # naming, so we encode it manually and append to the URL.
+                query_string = "?" + "&".join(f"ids[]={v}" for v in ids)
                 async with session.get(
-                    price_feeds_url, params={"ids": ids}
+                    price_feeds_url + query_string,
                 ) as response:
                     price_feeds += await response.json()
 

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -3,11 +3,12 @@ network:
   http_endpoint: "https://pythnet.rpcpool.com"
   ws_endpoint: "wss://pythnet.rpcpool.com"
   first_mapping: "AHtgzX45WTKfkPG53L6WYhGEXwQkN1BVknET3sVsLL8J"
-  crosschain_endpoint: "https://xc-mainnet.pyth.network"
+  crosschain_endpoint: "https://hermes.pyth.network"
   request_rate_limit: 10
   request_rate_period: 1
 events:
-  - DatadogEvent
+  # NOTE: Uncomment to enable Datadog metrics, see README.md for datadog credential docs.
+  # - DatadogEvent
   - LogEvent
 checks:
   global:


### PR DESCRIPTION
The HTTP library in hermes expects array parameters passed in URLs to be encoded with `ids[]=`, but the aiohttp library used here does not support encoding this way. This PR updates the call to hand-serialize the URL parameters to match hermes expectations.