### PR TITLE
format log events in json

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "pyth-observer"
-version = "0.2.0"
+version = "0.2.1"
 description = "Alerts and stuff"
 authors = []
 readme = "README.md"

--- a/pyth_observer/check/price_feed.py
+++ b/pyth_observer/check/price_feed.py
@@ -82,16 +82,13 @@ class PriceFeedOfflineCheck(PriceFeedCheck):
 
     def error_message(self) -> str:
         distance = self.__state.latest_block_slot - self.__state.latest_trading_slot
-        return dedent(
-            f"""
-            {self.__state.symbol} is offline (either non-trading/stale).
-            It is not updated for {distance} slots.
-
-            Latest trading slot: {self.__state.latest_trading_slot}
-            Block slot: {self.__state.latest_block_slot}
-            """
-        ).strip()
-
+        return {
+            "msg": f"{self.__state.symbol} is offline (either non-trading/stale). Last update {distance} slots ago.",
+            "type": "PriceFeedCheck",
+            "symbol": self.__state.symbol,
+            "latest_trading_slot": self.__state.latest_trading_slot,
+            "block_slot": self.__state.latest_block_slot
+        }
 
 class PriceFeedCoinGeckoCheck(PriceFeedCheck):
     def __init__(self, state: PriceFeedState, config: PriceFeedCheckConfig):
@@ -128,14 +125,13 @@ class PriceFeedCoinGeckoCheck(PriceFeedCheck):
         return False
 
     def error_message(self) -> str:
-        return dedent(
-            f"""
-            {self.__state.symbol} is too far from Coingecko's price.
-
-            Pyth price: {self.__state.price_aggregate}
-            Coingecko price: {self.__state.coingecko_price}
-            """
-        ).strip()
+        return {
+            "msg": f"{self.__state.symbol} is too far from Coingecko's price.",
+            "type": "PriceFeedCheck",
+            "symbol": self.__state.symbol,
+            "pyth_price": self.__state.price_aggregate,
+            "coingecko_price": self.__state.coingecko_price
+        }
 
 
 class PriceFeedConfidenceIntervalCheck(PriceFeedCheck):
@@ -159,14 +155,12 @@ class PriceFeedConfidenceIntervalCheck(PriceFeedCheck):
         return False
 
     def error_message(self) -> str:
-        return dedent(
-            f"""
-            {self.__state.symbol} confidence interval is too low.
-
-            Confidence interval: {self.__state.confidence_interval_aggregate}
-            """
-        ).strip()
-
+        return {
+            "msg": f"{self.__state.symbol} confidence interval is too low.",
+            "type": "PriceFeedCheck",
+            "symbol": self.__state.symbol,
+            "confidence_interval": self.__state.confidence_interval_aggregate
+        }
 
 class PriceFeedCrossChainOnlineCheck(PriceFeedCheck):
     def __init__(self, state: PriceFeedState, config: PriceFeedCheckConfig):
@@ -216,13 +210,12 @@ class PriceFeedCrossChainOnlineCheck(PriceFeedCheck):
         else:
             publish_time = arrow.get(0)
 
-        return dedent(
-            f"""
-            {self.__state.symbol} isn't online at the price service.
-
-            Last publish time: {publish_time.format('YYYY-MM-DD HH:mm:ss ZZ')}
-            """
-        ).strip()
+        return {
+            "msg": f"{self.__state.symbol} isn't online at the price service.",
+            "type": "PriceFeedCheck",
+            "symbol": self.__state.symbol,
+            "last_publish_time": publish_time.format('YYYY-MM-DD HH:mm:ss ZZ')
+        }
 
 
 class PriceFeedCrossChainDeviationCheck(PriceFeedCheck):
@@ -277,14 +270,13 @@ class PriceFeedCrossChainDeviationCheck(PriceFeedCheck):
             if self.__state.crosschain_price
             else None
         )
-        return dedent(
-            f"""
-            {self.__state.symbol} is too far at the price service.
-
-            Price: {self.__state.price_aggregate}
-            Price at price service: {price}
-            """
-        ).strip()
+        return {
+            "msg": f"{self.__state.symbol} is too far at the price service.",
+            "type": "PriceFeedCheck",
+            "symbol": self.__state.symbol,
+            "price": self.__state.price_aggregate,
+            "price_at_price_service": price
+        }
 
 
 PRICE_FEED_CHECKS = [

--- a/pyth_observer/check/price_feed.py
+++ b/pyth_observer/check/price_feed.py
@@ -87,8 +87,9 @@ class PriceFeedOfflineCheck(PriceFeedCheck):
             "type": "PriceFeedCheck",
             "symbol": self.__state.symbol,
             "latest_trading_slot": self.__state.latest_trading_slot,
-            "block_slot": self.__state.latest_block_slot
+            "block_slot": self.__state.latest_block_slot,
         }
+
 
 class PriceFeedCoinGeckoCheck(PriceFeedCheck):
     def __init__(self, state: PriceFeedState, config: PriceFeedCheckConfig):
@@ -130,7 +131,7 @@ class PriceFeedCoinGeckoCheck(PriceFeedCheck):
             "type": "PriceFeedCheck",
             "symbol": self.__state.symbol,
             "pyth_price": self.__state.price_aggregate,
-            "coingecko_price": self.__state.coingecko_price
+            "coingecko_price": self.__state.coingecko_price,
         }
 
 
@@ -159,8 +160,9 @@ class PriceFeedConfidenceIntervalCheck(PriceFeedCheck):
             "msg": f"{self.__state.symbol} confidence interval is too low.",
             "type": "PriceFeedCheck",
             "symbol": self.__state.symbol,
-            "confidence_interval": self.__state.confidence_interval_aggregate
+            "confidence_interval": self.__state.confidence_interval_aggregate,
         }
+
 
 class PriceFeedCrossChainOnlineCheck(PriceFeedCheck):
     def __init__(self, state: PriceFeedState, config: PriceFeedCheckConfig):
@@ -214,7 +216,7 @@ class PriceFeedCrossChainOnlineCheck(PriceFeedCheck):
             "msg": f"{self.__state.symbol} isn't online at the price service.",
             "type": "PriceFeedCheck",
             "symbol": self.__state.symbol,
-            "last_publish_time": publish_time.format('YYYY-MM-DD HH:mm:ss ZZ')
+            "last_publish_time": publish_time.format("YYYY-MM-DD HH:mm:ss ZZ"),
         }
 
 
@@ -275,7 +277,7 @@ class PriceFeedCrossChainDeviationCheck(PriceFeedCheck):
             "type": "PriceFeedCheck",
             "symbol": self.__state.symbol,
             "price": self.__state.price_aggregate,
-            "price_at_price_service": price
+            "price_at_price_service": price,
         }
 
 

--- a/pyth_observer/check/price_feed.py
+++ b/pyth_observer/check/price_feed.py
@@ -1,7 +1,6 @@
 import time
 from dataclasses import dataclass
 from datetime import datetime
-from textwrap import dedent
 from typing import Dict, Optional, Protocol, runtime_checkable
 from zoneinfo import ZoneInfo
 

--- a/pyth_observer/check/price_feed.py
+++ b/pyth_observer/check/price_feed.py
@@ -42,7 +42,7 @@ class PriceFeedCheck(Protocol):
     def run(self) -> bool:
         ...
 
-    def error_message(self) -> str:
+    def error_message(self) -> dict:
         ...
 
 
@@ -80,7 +80,7 @@ class PriceFeedOfflineCheck(PriceFeedCheck):
         # Fail
         return False
 
-    def error_message(self) -> str:
+    def error_message(self) -> dict:
         distance = self.__state.latest_block_slot - self.__state.latest_trading_slot
         return {
             "msg": f"{self.__state.symbol} is offline (either non-trading/stale). Last update {distance} slots ago.",
@@ -124,7 +124,7 @@ class PriceFeedCoinGeckoCheck(PriceFeedCheck):
         # Fail
         return False
 
-    def error_message(self) -> str:
+    def error_message(self) -> dict:
         return {
             "msg": f"{self.__state.symbol} is too far from Coingecko's price.",
             "type": "PriceFeedCheck",
@@ -154,7 +154,7 @@ class PriceFeedConfidenceIntervalCheck(PriceFeedCheck):
         # Fail
         return False
 
-    def error_message(self) -> str:
+    def error_message(self) -> dict:
         return {
             "msg": f"{self.__state.symbol} confidence interval is too low.",
             "type": "PriceFeedCheck",
@@ -204,7 +204,7 @@ class PriceFeedCrossChainOnlineCheck(PriceFeedCheck):
         # Fail
         return False
 
-    def error_message(self) -> str:
+    def error_message(self) -> dict:
         if self.__state.crosschain_price:
             publish_time = arrow.get(self.__state.crosschain_price["publish_time"])
         else:
@@ -263,7 +263,7 @@ class PriceFeedCrossChainDeviationCheck(PriceFeedCheck):
         # Fail
         return False
 
-    def error_message(self) -> str:
+    def error_message(self) -> dict:
         # It can never happen because of the check logic but linter could not understand it.
         price = (
             self.__state.crosschain_price["price"]

--- a/pyth_observer/check/publisher.py
+++ b/pyth_observer/check/publisher.py
@@ -81,17 +81,14 @@ class PublisherWithinAggregateConfidenceCheck(PublisherCheck):
     def error_message(self) -> str:
         diff = self.__state.price - self.__state.price_aggregate
         intervals_away = abs(diff / self.__state.confidence_interval_aggregate)
-
-        return dedent(
-            f"""
-            {self.__state.publisher_name} price not within aggregate confidence.
-            It is {intervals_away} times away from confidence.
-
-            Symbol: {self.__state.symbol}
-            Publisher price: {self.__state.price} ± {self.__state.confidence_interval}
-            Aggregate price: {self.__state.price_aggregate} ± {self.__state.confidence_interval_aggregate}
-            """
-        ).strip()
+        return {
+            "msg": f"{self.__state.publisher_name} price is {intervals_away} times away from confidence.",
+            "type": "PublisherCheck",
+            "publisher": self.__state.publisher_name,
+            "symbol": self.__state.symbol,
+            "publisher_price": f"{self.__state.price} ± {self.__state.confidence_interval}",
+            "aggregate_price": f"{self.__state.price_aggregate} ± {self.__state.confidence_interval_aggregate}"
+        }
 
 
 class PublisherConfidenceIntervalCheck(PublisherCheck):
@@ -120,15 +117,14 @@ class PublisherConfidenceIntervalCheck(PublisherCheck):
         return False
 
     def error_message(self) -> str:
-        return dedent(
-            f"""
-            {self.__state.publisher_name} confidence interval is too tight.
-
-            Symbol: {self.__state.symbol}
-            Price: {self.__state.price}
-            Confidence interval: {self.__state.confidence_interval}
-            """
-        ).strip()
+        return {
+            "msg": f"{self.__state.publisher_name} confidence interval is too tight.",
+            "type": "PublisherCheck",
+            "publisher": self.__state.publisher_name,
+            "symbol": self.__state.symbol,
+            "price": self.__state.price,
+            "confidence_interval": self.__state.confidence_interval
+        }
 
 
 class PublisherOfflineCheck(PublisherCheck):
@@ -156,15 +152,14 @@ class PublisherOfflineCheck(PublisherCheck):
 
     def error_message(self) -> str:
         distance = self.__state.latest_block_slot - self.__state.slot
-        return dedent(
-            f"""
-            {self.__state.publisher_name} hasn't published recently for {distance} slots.
-
-            Symbol: {self.__state.symbol}
-            Publisher slot: {self.__state.slot}
-            Aggregate slot: {self.__state.aggregate_slot}
-            """
-        ).strip()
+        return {
+            "msg": f"{self.__state.publisher_name} hasn't published recently for {distance} slots.",
+            "type": "PublisherCheck",
+            "publisher": self.__state.publisher_name,
+            "symbol": self.__state.symbol,
+            "publisher_slot": self.__state.slot,
+            "aggregate_slot": self.__state.aggregate_slot
+        }
 
 
 class PublisherPriceCheck(PublisherCheck):
@@ -205,17 +200,15 @@ class PublisherPriceCheck(PublisherCheck):
 
     def error_message(self) -> str:
         deviation = (self.ci_adjusted_price_diff() / self.__state.price_aggregate) * 100
-
-        return dedent(
-            f"""
-            {self.__state.publisher_name} price is too far from aggregate price.
-
-            Symbol: {self.__state.symbol}
-            Publisher price: {self.__state.price} ± {self.__state.confidence_interval}
-            Aggregate price: {self.__state.price_aggregate} ± {self.__state.confidence_interval_aggregate}
-            Deviation: {deviation}%
-            """
-        ).strip()
+        return {
+            "msg": f"{self.__state.publisher_name} price is too far from aggregate price.",
+            "type": "PublisherCheck",
+            "publisher": self.__state.publisher_name,
+            "symbol": self.__state.symbol,
+            "publisher_price": f"{self.__state.price} ± {self.__state.confidence_interval}",
+            "aggregate_price": f"{self.__state.price_aggregate} ± {self.__state.confidence_interval_aggregate}",
+            "deviation": deviation
+        }
 
     # Returns the distance between the aggregate price and the closest side of the publisher's confidence interval
     # Returns 0 if the aggregate price is within the publisher's confidence interval.

--- a/pyth_observer/check/publisher.py
+++ b/pyth_observer/check/publisher.py
@@ -87,7 +87,7 @@ class PublisherWithinAggregateConfidenceCheck(PublisherCheck):
             "publisher": self.__state.publisher_name,
             "symbol": self.__state.symbol,
             "publisher_price": f"{self.__state.price} ± {self.__state.confidence_interval}",
-            "aggregate_price": f"{self.__state.price_aggregate} ± {self.__state.confidence_interval_aggregate}"
+            "aggregate_price": f"{self.__state.price_aggregate} ± {self.__state.confidence_interval_aggregate}",
         }
 
 
@@ -123,7 +123,7 @@ class PublisherConfidenceIntervalCheck(PublisherCheck):
             "publisher": self.__state.publisher_name,
             "symbol": self.__state.symbol,
             "price": self.__state.price,
-            "confidence_interval": self.__state.confidence_interval
+            "confidence_interval": self.__state.confidence_interval,
         }
 
 
@@ -158,7 +158,7 @@ class PublisherOfflineCheck(PublisherCheck):
             "publisher": self.__state.publisher_name,
             "symbol": self.__state.symbol,
             "publisher_slot": self.__state.slot,
-            "aggregate_slot": self.__state.aggregate_slot
+            "aggregate_slot": self.__state.aggregate_slot,
         }
 
 
@@ -207,7 +207,7 @@ class PublisherPriceCheck(PublisherCheck):
             "symbol": self.__state.symbol,
             "publisher_price": f"{self.__state.price} ± {self.__state.confidence_interval}",
             "aggregate_price": f"{self.__state.price_aggregate} ± {self.__state.confidence_interval_aggregate}",
-            "deviation": deviation
+            "deviation": deviation,
         }
 
     # Returns the distance between the aggregate price and the closest side of the publisher's confidence interval

--- a/pyth_observer/check/publisher.py
+++ b/pyth_observer/check/publisher.py
@@ -38,7 +38,7 @@ class PublisherCheck(Protocol):
     def run(self) -> bool:
         ...
 
-    def error_message(self) -> str:
+    def error_message(self) -> dict:
         ...
 
 
@@ -78,7 +78,7 @@ class PublisherWithinAggregateConfidenceCheck(PublisherCheck):
         # Fail
         return False
 
-    def error_message(self) -> str:
+    def error_message(self) -> dict:
         diff = self.__state.price - self.__state.price_aggregate
         intervals_away = abs(diff / self.__state.confidence_interval_aggregate)
         return {
@@ -116,7 +116,7 @@ class PublisherConfidenceIntervalCheck(PublisherCheck):
         # Fail
         return False
 
-    def error_message(self) -> str:
+    def error_message(self) -> dict:
         return {
             "msg": f"{self.__state.publisher_name} confidence interval is too tight.",
             "type": "PublisherCheck",
@@ -150,7 +150,7 @@ class PublisherOfflineCheck(PublisherCheck):
         # Fail
         return False
 
-    def error_message(self) -> str:
+    def error_message(self) -> dict:
         distance = self.__state.latest_block_slot - self.__state.slot
         return {
             "msg": f"{self.__state.publisher_name} hasn't published recently for {distance} slots.",
@@ -198,7 +198,7 @@ class PublisherPriceCheck(PublisherCheck):
         # Fail
         return False
 
-    def error_message(self) -> str:
+    def error_message(self) -> dict:
         deviation = (self.ci_adjusted_price_diff() / self.__state.price_aggregate) * 100
         return {
             "msg": f"{self.__state.publisher_name} price is too far from aggregate price.",

--- a/pyth_observer/check/publisher.py
+++ b/pyth_observer/check/publisher.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from textwrap import dedent
 from typing import Dict, Protocol, runtime_checkable
 
 from pythclient.pythaccounts import PythPriceStatus

--- a/pyth_observer/event.py
+++ b/pyth_observer/event.py
@@ -16,6 +16,7 @@ from pyth_observer.models import Publisher
 
 load_dotenv()
 
+
 class Context(TypedDict):
     network: str
     publishers: Dict[str, Publisher]

--- a/pyth_observer/event.py
+++ b/pyth_observer/event.py
@@ -1,5 +1,6 @@
+import json
 import os
-from typing import Dict, Literal, Protocol, TypedDict, cast
+from typing import Dict, Protocol, TypedDict, cast
 
 import aiohttp
 from datadog_api_client.api_client import AsyncApiClient as DatadogAPI
@@ -38,7 +39,7 @@ class DatadogEvent(Event):
     async def send(self):
         # Publisher checks expect the key -> name mapping of publishers when
         # generating the error title/message.
-        text = self.check.error_message()
+        event = self.check.error_message()
 
         # An example is: PriceFeedOfflineCheck-Crypto.AAVE/USD
         aggregation_key = f"{self.check.__class__.__name__}-{self.check.state().symbol}"
@@ -50,8 +51,8 @@ class DatadogEvent(Event):
 
         event = EventCreateRequest(
             aggregation_key=aggregation_key,
-            title=text.split("\n")[0],
-            text=text,
+            title=event["msg"],
+            text=json.dumps(event),
             tags=[
                 "service:observer",
                 f"network:{self.context['network']}",

--- a/pyth_observer/event.py
+++ b/pyth_observer/event.py
@@ -98,7 +98,7 @@ class LogEvent(Event):
         text = self.check.error_message()
 
         level = cast(LogEventLevel, os.environ.get("LOG_EVENT_LEVEL", "INFO"))
-        logger.log(level, text.replace("\n", ". "))
+        logger.log(level, text)
 
 
 class TelegramEvent(Event):

--- a/pyth_observer/event.py
+++ b/pyth_observer/event.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from typing import Dict, Literal, Protocol, TypedDict, cast
 
 import aiohttp


### PR DESCRIPTION
this now creates logs with the following format:
```
{
  "text": "2024-05-09 17:06:54.951 | INFO     | pyth_observer.event:send:97 - dv (5ZLaVaVJdvdqGmvnS4jYgJ7k54Kdev7f1q5LDytjwqJ6) price is too far from aggregate price.\n",
  "record": {
    "elapsed": { "repr": "0:01:02.179121", "seconds": 62.179121 },
    "exception": null,
    "extra": {
      "msg": "dv (5ZLaVaVJdvdqGmvnS4jYgJ7k54Kdev7f1q5LDytjwqJ6) price is too far from aggregate price.",
      "type": "PublisherCheck",
      "publisher": "dv (5ZLaVaVJdvdqGmvnS4jYgJ7k54Kdev7f1q5LDytjwqJ6)",
      "symbol": "Crypto.ENJ/USD",
      "publisher_price": "0.31184499 ± 0.00585499",
      "aggregate_price": "0.29085248 ± 0.00217723",
      "deviation": 5.204535302569867
    },
    "file": {
      "name": "event.py",
      "path": "/Users/ayazabbas/dev/pyth/pyth-observer/pyth_observer/event.py"
    },
    "function": "send",
    "level": { "icon": "ℹ️", "name": "INFO", "no": 20 },
    "line": 97,
    "message": "dv (5ZLaVaVJdvdqGmvnS4jYgJ7k54Kdev7f1q5LDytjwqJ6) price is too far from aggregate price.",
    "module": "event",
    "name": "pyth_observer.event",
    "process": { "id": 60108, "name": "MainProcess" },
    "thread": { "id": 8252029632, "name": "MainThread" },
    "time": {
      "repr": "2024-05-09 17:06:54.951338+01:00",
      "timestamp": 1715270814.951338
    }
  }
}
```