### PR TITLE
Add zenduty integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,11 @@ cover: ve
 lint: lint.python
 #lint: lint.yaml - argh, RHEL is too old to do this by default
 
-lint.python: ve
-	. ve/bin/activate; flake8 observer.py pyth_observer/
+lint.python:
+	poetry run isort pyth_observer/
+	poetry run black pyth_observer/
+	poetry run pyright pyth_observer/
+	poetry run pyflakes pyth_observer/
 
 lint.yaml:
 	yamllint .

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Event types are configured via environment variables:
 - `TelegramEvent`
   - `TELEGRAM_BOT_TOKEN` - API token for the Telegram bot
 
+- `ZendutyEvent`
+  - `ZENDUTY_INTEGRATION_KEY` - Integration key for Zenduty service API integration
+  - `OPEN_ALERTS_FILE` - Path to local file used for persisting open alerts
+
 ## Finding the Telegram Group Chat ID
 
 To integrate Telegram events with the Observer, you need the Telegram group chat ID. Here's how you can find it:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "pyth-observer"
-version = "0.3.0"
+version = "0.2.6"
 description = "Alerts and stuff"
 authors = []
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "pyth-observer"
-version = "0.2.3"
+version = "0.3.0"
 description = "Alerts and stuff"
 authors = []
 readme = "README.md"

--- a/pyth_observer/dispatch.py
+++ b/pyth_observer/dispatch.py
@@ -94,10 +94,6 @@ class Dispatch:
         # Check open alerts and resolve those that are older than 2 minutes
         if "ZendutyEvent" in self.config["events"]:
 
-            # Write open alerts to file to ensure persistence
-            with open(self.open_alerts_file, "w") as file:
-                json.dump(self.open_alerts, file)
-
             to_remove = []
             current_time = datetime.now()
             for identifier, last_failure in self.open_alerts.items():
@@ -113,6 +109,10 @@ class Dispatch:
 
             for identifier in to_remove:
                 del self.open_alerts[identifier]
+
+            # Write open alerts to file to ensure persistence
+            with open(self.open_alerts_file, "w") as file:
+                json.dump(self.open_alerts, file)
 
     def check_price_feed(self, state: PriceFeedState) -> List[Check]:
         failed_checks: List[Check] = []

--- a/pyth_observer/dispatch.py
+++ b/pyth_observer/dispatch.py
@@ -91,7 +91,7 @@ class Dispatch:
 
         await asyncio.gather(*sent_events)
 
-        # Check open alerts and resolve those that are older than 3 minutes
+        # Check open alerts and resolve those that are older than 2 minutes
         if "ZendutyEvent" in self.config["events"]:
 
             # Write open alerts to file to ensure persistence

--- a/pyth_observer/dispatch.py
+++ b/pyth_observer/dispatch.py
@@ -91,7 +91,7 @@ class Dispatch:
 
         await asyncio.gather(*sent_events)
 
-        # Check open alerts and resolve those that are older than 5 minutes
+        # Check open alerts and resolve those that are older than 3 minutes
         if "ZendutyEvent" in self.config["events"]:
 
             # Write open alerts to file to ensure persistence

--- a/pyth_observer/event.py
+++ b/pyth_observer/event.py
@@ -11,8 +11,9 @@ from dotenv import load_dotenv
 from loguru import logger
 
 from pyth_observer.check import Check
-from pyth_observer.check.publisher import PublisherCheck
+from pyth_observer.check.publisher import PublisherCheck, PublisherState
 from pyth_observer.models import Publisher
+from pyth_observer.zenduty import send_zenduty_alert
 
 load_dotenv()
 
@@ -143,3 +144,27 @@ class TelegramEvent(Event):
                         logger.error(
                             f"Failed to send Telegram message: {response_text}"
                         )
+
+
+class ZendutyEvent(Event):
+    def __init__(self, check: Check, context: Context):
+        self.check = check
+        self.context = context
+
+    async def send(self):
+        event_details = self.check.error_message()
+        summary = ""
+        for key, value in event_details.items():
+            summary += f"{key}: {value}\n"
+
+        alert_identifier = (
+            f"{self.check.__class__.__name__}-{self.check.state().symbol}"
+        )
+        state = self.check.state()
+        if isinstance(state, PublisherState):
+            alert_identifier += f"-{state.publisher_name}"
+
+        logger.debug(f"Sending Zenduty alert for {alert_identifier}")
+        await send_zenduty_alert(
+            alert_identifier=alert_identifier, message=alert_identifier, summary=summary
+        )

--- a/pyth_observer/zenduty.py
+++ b/pyth_observer/zenduty.py
@@ -37,7 +37,7 @@ async def send_zenduty_alert(alert_identifier, message, resolved=False, summary=
                             f"Received 429 Too Many Requests for {alert_identifier}. Retrying in 1 second..."
                         )
                         await asyncio.sleep(
-                            min(30, 2 ^ retries)
+                            min(30, 2**retries)
                         )  # Backoff before retrying, wait upto 30s
                     else:
                         logger.error(

--- a/pyth_observer/zenduty.py
+++ b/pyth_observer/zenduty.py
@@ -1,0 +1,50 @@
+import asyncio
+import hashlib
+import os
+
+import aiohttp
+from loguru import logger
+
+url = f"https://www.zenduty.com/api/events/{os.environ['ZENDUTY_INTEGRATION_KEY']}/"
+headers = {"Content-Type": "application/json"}
+
+
+async def send_zenduty_alert(alert_identifier, message, resolved=False, summary=""):
+    # Use a hash of the alert_identifier as a unique id for the alert.
+    # Take the first 32 characters due to length limit of the api.
+    entity_id = hashlib.sha256(alert_identifier.encode("utf-8")).hexdigest()[:32]
+
+    alert_type = "resolved" if resolved else "critical"
+
+    data = {
+        "alert_type": alert_type,
+        "message": message,
+        "summary": summary,
+        "entity_id": entity_id,
+    }
+
+    async with aiohttp.ClientSession() as session:
+        max_retries = 30
+        retries = 0
+        while retries < max_retries:
+            async with session.post(url, json=data, headers=headers) as response:
+                if 200 <= response.status < 300:
+                    return response  # Success case, return response
+                elif response.status == 429:
+                    retries += 1
+                    if retries < max_retries:
+                        logger.error(
+                            f"Received 429 Too Many Requests for {alert_identifier}. Retrying in 1 second..."
+                        )
+                        await asyncio.sleep(1)  # Wait for 1 second before retrying
+                    else:
+                        logger.error(
+                            f"Failed to send Zenduty event message for {alert_identifier} after {max_retries} retries."
+                        )
+                        return response  # Return response after max retries
+                else:
+                    response_text = await response.text()
+                    logger.error(
+                        f"{response.status} Failed to send Zenduty event message for {alert_identifier}: {response_text}"
+                    )
+                    return response  # Non-retryable failure


### PR DESCRIPTION
Adds a Zenduty Event type, which requires us to manually resolve an incident once it surpasses so I have added logic to monitor open alerts and resolve them if the last alert was > 2 minutes ago. Open alerts are written to a file for persistence across app restarts, so we don't end up with orphaned unresolved incidents.