### PR TITLE
reduce noise of zenduty alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "pyth-observer"
-version = "0.2.6"
+version = "0.2.7"
 description = "Alerts and stuff"
 authors = []
 readme = "README.md"

--- a/pyth_observer/dispatch.py
+++ b/pyth_observer/dispatch.py
@@ -119,7 +119,7 @@ class Dispatch:
                     if response and 200 <= response.status < 300:
                         to_remove.append(identifier)
                 elif info["failures"] > 2:
-                    # Raise alert if the check has failed more than once without self-resolving
+                    # Raise alert if the check has failed more than twice before self-resolving
                     await self.zenduty_events[identifier].send()
 
             for identifier in to_remove:

--- a/pyth_observer/dispatch.py
+++ b/pyth_observer/dispatch.py
@@ -108,10 +108,10 @@ class Dispatch:
             to_remove = []
             current_time = datetime.now()
             for identifier, info in self.open_alerts.items():
-                # Resolve the alert if it last failed > 5 minutes ago
+                # Resolve the alert if it last failed > 2 minutes ago
                 if current_time - datetime.fromisoformat(
                     info["last_failure"]
-                ) >= timedelta(minutes=5):
+                ) >= timedelta(minutes=2):
                     logger.debug(f"Resolving Zenduty alert {identifier}")
                     response = await send_zenduty_alert(
                         alert_identifier=identifier, message=identifier, resolved=True

--- a/pyth_observer/dispatch.py
+++ b/pyth_observer/dispatch.py
@@ -124,6 +124,7 @@ class Dispatch:
 
             for identifier in to_remove:
                 del self.open_alerts[identifier]
+                del self.zenduty_events[identifier]
 
             # Write open alerts to file to ensure persistence
             with open(self.open_alerts_file, "w") as file:

--- a/pyth_observer/zenduty.py
+++ b/pyth_observer/zenduty.py
@@ -33,11 +33,12 @@ async def send_zenduty_alert(alert_identifier, message, resolved=False, summary=
                 elif response.status == 429:
                     retries += 1
                     if retries < max_retries:
+                        sleeptime = min(30, 2**retries)
                         logger.error(
-                            f"Received 429 Too Many Requests for {alert_identifier}. Retrying in 1 second..."
+                            f"Received 429 Too Many Requests for {alert_identifier}. Retrying in {sleeptime} s..."
                         )
                         await asyncio.sleep(
-                            min(30, 2**retries)
+                            sleeptime
                         )  # Backoff before retrying, wait upto 30s
                     else:
                         logger.error(


### PR DESCRIPTION
Tested locally and works as expected. Should greatly reduce noise by only alerting if a check fails 3 times without self-resolving within 2 minutes.