### PR TITLE
fix: skip PublisherStalledCheck if PublisherOfflineCheck fails

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "pyth-observer"
-version = "0.2.7"
+version = "0.2.8"
 description = "Alerts and stuff"
 authors = []
 readme = "README.md"

--- a/pyth_observer/__init__.py
+++ b/pyth_observer/__init__.py
@@ -144,6 +144,7 @@ class Observer:
                             PublisherState(
                                 publisher_name=publisher_name,
                                 symbol=product.attrs["symbol"],
+                                asset_type=product.attrs["asset_type"],
                                 public_key=component.publisher_key,
                                 confidence_interval=component.latest_price_info.confidence_interval,
                                 confidence_interval_aggregate=price_account.aggregate_price_info.confidence_interval,

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -47,6 +47,7 @@ checks:
     PublisherStalledCheck:
       enable: true
       stall_time_limit: 60
+      max_slot_distance: 25
   # Per-symbol config
   Crypto.MNGO/USD:
     PriceFeedOfflineCheck:

--- a/tests/test_checks_publisher.py
+++ b/tests/test_checks_publisher.py
@@ -23,6 +23,7 @@ def make_state(
     return PublisherState(
         publisher_name="publisher",
         symbol="Crypto.BTC/USD",
+        asset_type="Crypto",
         public_key=SolanaPublicKey("2hgu6Umyokvo8FfSDdMa9nDKhcdv9Q4VvGNhRCeSWeD3"),
         status=PythPriceStatus.TRADING,
         aggregate_status=PythPriceStatus.TRADING,


### PR DESCRIPTION
we agree that `PublisherStalledCheck` should fulfil these 3 requirements:
- should be skipped when market hours is closed
- should be skipped when publisher is offline (`PublisherOfflineCheck` fails)
- should be skipped when `PublisherOfflineCheck` returns true but `distance > self.__abandoned_slot_distance`

there seems to be 2 ways we can do this:
- duplicating the offline check logic in `PublisherStalledCheck` including modifying the check to accept `max_slot_distance` and `abandoned_slot_distance` fields which don't really seem to belong there since this is for `PublisherOfflineCheck`
- make sure `PublisherStalledCheck` runs after `PublisherOfflineCheck` and keep track of the deps with flags

instead of modifying `PublisherStalledCheck` to also accept `max_slot_distance` and `abandoned_slot_distance` solely for the purpose of replicating the offline check, I have chosen the second option in this PR which is to modify `check_publisher()` so that we don't have to duplicate the offline check, this is definitely not without its drawback, which is that now the `check_publisher()` function becomes more complicated

update: previously I've tried to approach this issue using option 2 but it turns out changes the code to be more complicated and introduce dependencies that will make it more unmaintainable so I have reverted to the first option instead