### PR TITLE
fire zenduty alert when check fails 5 times in 5 mins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "pyth-observer"
-version = "0.2.7"
+version = "0.2.8"
 description = "Alerts and stuff"
 authors = []
 readme = "README.md"

--- a/pyth_observer/zenduty.py
+++ b/pyth_observer/zenduty.py
@@ -24,7 +24,7 @@ async def send_zenduty_alert(alert_identifier, message, resolved=False, summary=
     }
 
     async with aiohttp.ClientSession() as session:
-        max_retries = 30
+        max_retries = 5
         retries = 0
         while retries < max_retries:
             async with session.post(url, json=data, headers=headers) as response:


### PR DESCRIPTION
- This further reduces the noise from zenduty by only alerting if a check fails 5 times within 5 minutes.
- Subsequently we alert every 5 minutes if it continues to fail at that rate (this does not produce a new message though, it gets collated under the same incident).
- Or if the check failed < 5 timees in the latest 5min window, the alert is resolved.
- This should exactly match the current behaviour of datadog alerts. I ran the program for a couple hours last night and alerts aligned with the datadog alerts.