### PR TITLE
set customisable thresholds for zenduty alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ Event types are configured via environment variables:
   - `ZENDUTY_INTEGRATION_KEY` - Integration key for Zenduty service API integration
   - `OPEN_ALERTS_FILE` - Path to local file used for persisting open alerts
 
+### Zenduty Alert Thresholds
+By default: 
+- Zenduty alert will fire if a check fails 5 or more times within 5 minutes.
+- The alert will be resolved if the check failed < 4 times within 5 minutes.
+- Checks run approximately once per minute.
+- These thresholds can be overridden per check type in config.yaml
+  - `zenduty_alert_threshold`: number of failures in 5 minutes >= to this value trigger an alert
+  - `zenduty_resolution_threshold`: number of failures in 5 minutes <= this value resolve the alert
+
 ## Finding the Telegram Group Chat ID
 
 To integrate Telegram events with the Observer, you need the Telegram group chat ID. Here's how you can find it:

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ By default:
 - The alert will be resolved if the check failed < 4 times within 5 minutes.
 - Checks run approximately once per minute.
 - These thresholds can be overridden per check type in config.yaml
-  - `zenduty_alert_threshold`: number of failures in 5 minutes >= to this value trigger an alert
-  - `zenduty_resolution_threshold`: number of failures in 5 minutes <= this value resolve the alert
+  - `zenduty_alert_threshold`: number of failures in 5 minutes >= to this value trigger an alert (default: 5)
+  - `zenduty_resolution_threshold`: number of failures in 5 minutes <= this value resolve the alert (default: 3)
 
 ## Finding the Telegram Group Chat ID
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Observe Pyth on-chain price feeds and run sanity checks on the data.
 
 ## Usage
 
-Container images are available at https://gallery.ecr.aws/pyth-network/observer.
+Container images are available at https://github.com/pyth-network/pyth-observer/pkgs/container/pyth-observer
 
 To run Observer locally, make sure you have a recent version of [Poetry](https://python-poetry.org) installed and run:
 
@@ -39,7 +39,6 @@ Event types are configured via environment variables:
   - `OPEN_ALERTS_FILE` - Path to local file used for persisting open alerts
 
 ### Zenduty Alert Thresholds
-By default: 
 - Zenduty alert will fire if a check fails 5 or more times within 5 minutes.
 - The alert will be resolved if the check failed < 4 times within 5 minutes.
 - Checks run approximately once per minute.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "pyth-observer"
-version = "0.2.10"
+version = "0.2.11"
 description = "Alerts and stuff"
 authors = []
 readme = "README.md"

--- a/pyth_observer/dispatch.py
+++ b/pyth_observer/dispatch.py
@@ -186,6 +186,7 @@ class Dispatch:
                 and info["last_window_failures"] <= resolution_threshold
             ):
                 logger.debug(f"Resolving Zenduty alert {identifier}")
+                resolved = True
                 if info["sent"]:
                     response = await send_zenduty_alert(
                         identifier, identifier, resolved=True

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -11,6 +11,7 @@ events:
   # - DatadogEvent
   - LogEvent
   # - TelegramEvent
+  - ZendutyEvent
 checks:
   global:
     # Price feed checks
@@ -18,6 +19,8 @@ checks:
       enable: true
       max_slot_distance: 25
       abandoned_slot_distance: 100000
+      zenduty_alert_threshold: 3
+      zenduty_resolution_threshold: 0
     PriceFeedCoinGeckoCheck:
       enable: true
       max_deviation: 5
@@ -44,11 +47,15 @@ checks:
       enable: true
       max_slot_distance: 25
       max_aggregate_distance: 6
+      zenduty_alert_threshold: 5
+      zenduty_resolution_threshold: 2
     PublisherStalledCheck:
       enable: false
       stall_time_limit: 30
       abandoned_time_limit: 600
       max_slot_distance: 25
+      zenduty_alert_threshold: 1
+      zenduty_resolution_threshold: 0
   # Per-symbol config
   Crypto.MNGO/USD:
     PriceFeedOfflineCheck:


### PR DESCRIPTION
Some checks are noisier than others, this change allows us to set alert and resolution thresholds per check type.