### PR TITLE
Exclude coming soon feeds from alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "pyth-observer"
-version = "0.3.0"
+version = "0.3.1"
 description = "Alerts and stuff"
 authors = []
 readme = "README.md"

--- a/pyth_observer/__init__.py
+++ b/pyth_observer/__init__.py
@@ -90,6 +90,12 @@ class Observer:
                 # for each publisher).
                 states = []
                 price_accounts = await self.get_pyth_prices(product)
+
+                # If the min_publishers is set to 255, this is a "coming soon" feed and is not live yet
+                # Skip alerting on these feeds
+                if product.prices[PythPriceType.PRICE].min_publishers == 255:
+                    continue
+
                 crosschain_price = crosschain_prices.get(
                     b58decode(product.first_price_account_key.key).hex(), None
                 )


### PR DESCRIPTION
If a feed's min_publishers count is 255, it's not live yet (coming soon.) These feeds should be excluded from alerts.