### PR TITLE
Revert #82

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "pyth-observer"
-version = "0.3.1"
+version = "0.3.2"
 description = "Alerts and stuff"
 authors = []
 readme = "README.md"

--- a/pyth_observer/__init__.py
+++ b/pyth_observer/__init__.py
@@ -91,11 +91,6 @@ class Observer:
                 states = []
                 price_accounts = await self.get_pyth_prices(product)
 
-                # If the min_publishers is set to 255, this is a "coming soon" feed and is not live yet
-                # Skip alerting on these feeds
-                if product.prices[PythPriceType.PRICE].min_publishers == 255:
-                    continue
-
                 crosschain_price = crosschain_prices.get(
                     b58decode(product.first_price_account_key.key).hex(), None
                 )


### PR DESCRIPTION
Revert #82 since the check already exists [here](https://github.com/pyth-network/pyth-observer/blob/7abc071b052c404ace5ae3cd462b5f1f8f7b764f/pyth_observer/__init__.py#L106-L111)