### PR TITLE
update zenduty endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "pyth-observer"
-version = "0.3.3"
+version = "0.3.4"
 description = "Alerts and stuff"
 authors = []
 readme = "README.md"

--- a/pyth_observer/zenduty.py
+++ b/pyth_observer/zenduty.py
@@ -9,7 +9,7 @@ headers = {"Content-Type": "application/json"}
 
 
 async def send_zenduty_alert(alert_identifier, message, resolved=False, summary=""):
-    url = f"https://www.zenduty.com/api/events/{os.environ['ZENDUTY_INTEGRATION_KEY']}/"
+    url = f"https://events.zenduty.com/api/events/{os.environ['ZENDUTY_INTEGRATION_KEY']}/"
     # Use a hash of the alert_identifier as a unique id for the alert.
     # Take the first 32 characters due to length limit of the api.
     entity_id = hashlib.sha256(alert_identifier.encode("utf-8")).hexdigest()[:32]


### PR DESCRIPTION
API Integration is being [deprecated](https://zenduty.com/docs/api-integration/).

[IMPORTANT] We're phasing out the API-

> ⚠️ **[Integration]** We're phasing out the API-Integration in favour of the [Generic Integration](https://zenduty.com/docs/generic-integration/). Starting **October 15th, 2024**, no new API-Integration integrations can be created. We will continue to support the existing API-Integrations until **March 31st, 2025**, after which they will stop working. We recommend you to migrate the existing API-Integrations to the [Generic Integration](https://zenduty.com/docs/generic-integration/) at your earliest convenience.